### PR TITLE
Use dedicated storage directory for SQLite database

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Um sistema web responsivo (mobile-first) para registrar e consolidar relatórios
 3. **Configurar subdomínio na Hostinger**
 4. **Fazer upload dos arquivos**
 
+### 🚀 Deploy com Coolify
+
+1. **Volume persistente**: No serviço do backend, monte um volume apontando para `/app/storage` para garantir que o arquivo `reports.db` seja preservado entre deploys.
+2. **Variável de ambiente**: Caso prefira outro caminho, defina a variável `DB_PATH` apontando para o arquivo dentro do volume (ex.: `/app/data/reports.db`).
+3. **Reconstruir a aplicação**: Após ajustar o volume ou a variável de ambiente, recrie o container para que o novo caminho seja aplicado.
+
 ## 📝 Como Usar
 
 ### 1. Relatório Diário de Atividades

--- a/backend/config.js
+++ b/backend/config.js
@@ -1,10 +1,11 @@
 const path = require('path');
 
-const defaultDbPath = path.join(__dirname, 'storage', 'reports.db');
+const defaultDbPath = path.resolve(__dirname, '..', 'storage', 'reports.db');
+const envDbPath = process.env.DB_PATH ? path.resolve(process.env.DB_PATH) : null;
 
 module.exports = {
   port: process.env.PORT || 3001,
-  dbPath: process.env.DB_PATH || defaultDbPath,
+  dbPath: envDbPath || defaultDbPath,
   corsOrigin: process.env.CORS_ORIGIN || ['http://localhost:3000', 'https://relatorios.thiagoriva.com'],
   nodeEnv: process.env.NODE_ENV || 'development'
 };

--- a/backend/config.js
+++ b/backend/config.js
@@ -1,6 +1,10 @@
+const path = require('path');
+
+const defaultDbPath = path.join(__dirname, 'storage', 'reports.db');
+
 module.exports = {
   port: process.env.PORT || 3001,
-  dbPath: process.env.DB_PATH || './database/reports.db',
+  dbPath: process.env.DB_PATH || defaultDbPath,
   corsOrigin: process.env.CORS_ORIGIN || ['http://localhost:3000', 'https://relatorios.thiagoriva.com'],
   nodeEnv: process.env.NODE_ENV || 'development'
 };

--- a/backend/ecosystem.config.js
+++ b/backend/ecosystem.config.js
@@ -1,4 +1,8 @@
 // Configuração para PM2 (gerenciador de processos Node.js)
+const path = require('path');
+
+const dbPath = path.join(__dirname, '..', 'storage', 'reports.db');
+
 module.exports = {
   apps: [{
     name: 'daily-report-api',
@@ -10,7 +14,7 @@ module.exports = {
     env: {
       NODE_ENV: 'production',
       PORT: 3001,
-      DB_PATH: './storage/reports.db'
+      DB_PATH: dbPath
     },
     error_file: './logs/err.log',
     out_file: './logs/out.log',

--- a/backend/ecosystem.config.js
+++ b/backend/ecosystem.config.js
@@ -10,7 +10,7 @@ module.exports = {
     env: {
       NODE_ENV: 'production',
       PORT: 3001,
-      DB_PATH: './database/reports.db'
+      DB_PATH: './storage/reports.db'
     },
     error_file: './logs/err.log',
     out_file: './logs/out.log',

--- a/backend/scripts/cleanDuplicates.js
+++ b/backend/scripts/cleanDuplicates.js
@@ -2,9 +2,11 @@
 
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
+const config = require('../config');
 
 // Conectar ao banco de dados
-const dbPath = path.join(__dirname, '../database/reports.db');
+const dbPath = path.resolve(config.dbPath);
+const dbDirectory = path.dirname(dbPath);
 const db = new sqlite3.Database(dbPath);
 
 async function cleanDuplicates() {
@@ -13,7 +15,7 @@ async function cleanDuplicates() {
   try {
     // 1. Backup de segurança
     console.log('📦 Criando backup de segurança...');
-    const backupPath = path.join(__dirname, `../database/backup_before_clean_${Date.now()}.db`);
+    const backupPath = path.join(dbDirectory, `backup_before_clean_${Date.now()}.db`);
     await new Promise((resolve, reject) => {
       db.exec(`VACUUM INTO '${backupPath}'`, (err) => {
         if (err) reject(err);

--- a/backend/scripts/createUser.js
+++ b/backend/scripts/createUser.js
@@ -1,9 +1,10 @@
 const bcrypt = require('bcryptjs');
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
+const config = require('../config');
 
 // Conectar ao banco de dados
-const dbPath = path.join(__dirname, '../database/reports.db');
+const dbPath = path.resolve(config.dbPath);
 const db = new sqlite3.Database(dbPath);
 
 async function createUser(nome, email, senha, role = 'tecnico') {

--- a/backend/scripts/dbAdmin.js
+++ b/backend/scripts/dbAdmin.js
@@ -33,7 +33,7 @@ const commands = {
 
   // Criar usuário admin
   createAdmin: (nome, email, senha) => {
-    if (!nome || !email || senha) {
+    if (!nome || !email || !senha) {
       console.log('❌ Uso: node dbAdmin.js createAdmin "Nome" "email@empresa.com" "senha123"');
       return;
     }

--- a/backend/scripts/dbAdmin.js
+++ b/backend/scripts/dbAdmin.js
@@ -2,9 +2,11 @@
 
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
+const config = require('../config');
 
 // Conectar ao banco de dados
-const dbPath = path.join(__dirname, '../database/reports.db');
+const dbPath = path.resolve(config.dbPath);
+const dbDirectory = path.dirname(dbPath);
 const db = new sqlite3.Database(dbPath);
 
 // Funções de administração
@@ -88,7 +90,7 @@ const commands = {
   // Backup do banco
   backup: () => {
     const fs = require('fs');
-    const backupPath = path.join(__dirname, `../database/backup_${new Date().toISOString().split('T')[0]}.db`);
+    const backupPath = path.join(dbDirectory, `backup_${new Date().toISOString().split('T')[0]}.db`);
     
     db.serialize(() => {
       db.exec(`VACUUM INTO '${backupPath}'`, (err) => {

--- a/configure-api-url.sh
+++ b/configure-api-url.sh
@@ -58,7 +58,8 @@ cat > .env.production << EOF
 NODE_ENV=production
 PORT=3000
 JWT_SECRET=MUDE_ESTA_CHAVE_EM_PRODUCAO_256_BITS_SEGURA
-DATABASE_PATH=./database/reports.db
+DATABASE_PATH=./backend/storage/reports.db
+DB_PATH=./backend/storage/reports.db
 
 # Frontend - URL da API no VPS
 REACT_APP_API_URL=$API_URL

--- a/configure-api-url.sh
+++ b/configure-api-url.sh
@@ -58,8 +58,8 @@ cat > .env.production << EOF
 NODE_ENV=production
 PORT=3000
 JWT_SECRET=MUDE_ESTA_CHAVE_EM_PRODUCAO_256_BITS_SEGURA
-DATABASE_PATH=./backend/storage/reports.db
-DB_PATH=./backend/storage/reports.db
+DATABASE_PATH=./storage/reports.db
+DB_PATH=./storage/reports.db
 
 # Frontend - URL da API no VPS
 REACT_APP_API_URL=$API_URL

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,11 +29,11 @@ fi
 
 # 1. Fazer backup do banco de dados
 log "Fazendo backup do banco de dados..."
-if [ -f "backend/database/reports.db" ]; then
+if [ -f "backend/storage/reports.db" ]; then
     BACKUP_DIR="backups"
     mkdir -p $BACKUP_DIR
     DATE=$(date +%Y%m%d_%H%M%S)
-    cp backend/database/reports.db "$BACKUP_DIR/reports_backup_$DATE.db"
+    cp backend/storage/reports.db "$BACKUP_DIR/reports_backup_$DATE.db"
     log "Backup criado: $BACKUP_DIR/reports_backup_$DATE.db"
 else
     warning "Banco de dados não encontrado, pulando backup..."
@@ -78,7 +78,8 @@ if [ ! -f ".env.production" ]; then
 NODE_ENV=production
 PORT=3001
 JWT_SECRET=MUDE_ESTA_CHAVE_EM_PRODUCAO_256_BITS_SEGURA
-DATABASE_PATH=./backend/database/reports.db
+DATABASE_PATH=./backend/storage/reports.db
+DB_PATH=./backend/storage/reports.db
 
 # Frontend (usado durante o build) - HOSTINGER
 REACT_APP_API_URL=https://api.report.thiagoriva.com/api

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,11 +29,11 @@ fi
 
 # 1. Fazer backup do banco de dados
 log "Fazendo backup do banco de dados..."
-if [ -f "backend/storage/reports.db" ]; then
+if [ -f "storage/reports.db" ]; then
     BACKUP_DIR="backups"
     mkdir -p $BACKUP_DIR
     DATE=$(date +%Y%m%d_%H%M%S)
-    cp backend/storage/reports.db "$BACKUP_DIR/reports_backup_$DATE.db"
+    cp storage/reports.db "$BACKUP_DIR/reports_backup_$DATE.db"
     log "Backup criado: $BACKUP_DIR/reports_backup_$DATE.db"
 else
     warning "Banco de dados não encontrado, pulando backup..."
@@ -78,8 +78,8 @@ if [ ! -f ".env.production" ]; then
 NODE_ENV=production
 PORT=3001
 JWT_SECRET=MUDE_ESTA_CHAVE_EM_PRODUCAO_256_BITS_SEGURA
-DATABASE_PATH=./backend/storage/reports.db
-DB_PATH=./backend/storage/reports.db
+DATABASE_PATH=./storage/reports.db
+DB_PATH=./storage/reports.db
 
 # Frontend (usado durante o build) - HOSTINGER
 REACT_APP_API_URL=https://api.report.thiagoriva.com/api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,12 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3001
-      - DATABASE_PATH=./database/reports.db
+      - DATABASE_PATH=/app/storage/reports.db
+      - DB_PATH=/app/storage/reports.db
       - JWT_SECRET=654fa045015da9f6ad62f2755a2b512c51ea43ec461dcade58687e7da97cd821
       - CORS_ORIGIN=https://relatorios.thiagoriva.com
     volumes:
-      - app_data:/app/database
+      - app_data:/app/storage
     restart: unless-stopped
 
 volumes:

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -7,7 +7,8 @@ module.exports = {
       NODE_ENV: 'production',
       PORT: 3000, // Porta padrão da Hostinger
       JWT_SECRET: 'sua_chave_jwt_super_secreta_aqui_256_bits_mude_em_producao',
-      DATABASE_PATH: './backend/database/reports.db'
+      DATABASE_PATH: './backend/storage/reports.db',
+      DB_PATH: './backend/storage/reports.db'
     },
     instances: 1,
     exec_mode: 'fork', // Fork ao invés de cluster para Hostinger

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,3 +1,7 @@
+const path = require('path');
+
+const storageDbPath = path.join(__dirname, 'storage', 'reports.db');
+
 module.exports = {
   apps: [{
     name: 'daily-report-api',
@@ -7,8 +11,8 @@ module.exports = {
       NODE_ENV: 'production',
       PORT: 3000, // Porta padrão da Hostinger
       JWT_SECRET: 'sua_chave_jwt_super_secreta_aqui_256_bits_mude_em_producao',
-      DATABASE_PATH: './backend/storage/reports.db',
-      DB_PATH: './backend/storage/reports.db'
+      DATABASE_PATH: storageDbPath,
+      DB_PATH: storageDbPath
     },
     instances: 1,
     exec_mode: 'fork', // Fork ao invés de cluster para Hostinger


### PR DESCRIPTION
## Summary
- point the default SQLite location to a dedicated storage directory and ensure the directory exists before opening the database
- load the schema with friendly errors and align admin scripts plus deployment tooling with the new storage path/DB_PATH variable
- document the Coolify volume requirement and keep an empty storage directory in version control

## Testing
- node -e "const db = require('./database/database.js'); console.log('✅ Banco de dados OK');"

------
https://chatgpt.com/codex/tasks/task_e_68cdc4e365b4832eb863ce37380e8bd6