### PR TITLE
Use configurable API base URL for auth requests

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,5 +1,7 @@
 import React, { createContext, useContext, useReducer, useEffect } from 'react';
 
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001/api';
+
 const AuthContext = createContext();
 
 // Tipos de ações
@@ -88,7 +90,7 @@ export const AuthProvider = ({ children }) => {
       }
 
       try {
-        const response = await fetch('http://localhost:3001/api/auth/verify', {
+        const response = await fetch(`${API_URL}/auth/verify`, {
           headers: {
             'Authorization': `Bearer ${token}`
           }
@@ -116,7 +118,7 @@ export const AuthProvider = ({ children }) => {
     dispatch({ type: ACTIONS.LOGIN_START });
 
     try {
-      const response = await fetch('http://localhost:3001/api/auth/login', {
+      const response = await fetch(`${API_URL}/auth/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- derive the API base URL from the environment inside the auth context
- update the token verification and login requests to reuse the configurable API base

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cdde2879ac832e84dfb31d5b4a14d5