### PR TITLE
Add user and audit tables to SQLite schema

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -1,3 +1,19 @@
+-- Tabela de Usuários
+CREATE TABLE IF NOT EXISTS usuarios (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    nome VARCHAR(150) NOT NULL,
+    email VARCHAR(150) NOT NULL UNIQUE,
+    senha VARCHAR(255) NOT NULL,
+    role VARCHAR(50) NOT NULL DEFAULT 'tecnico',
+    clusters_permitidos TEXT DEFAULT '[]',
+    ativo BOOLEAN DEFAULT 1,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_usuarios_email ON usuarios(email);
+CREATE INDEX IF NOT EXISTS idx_usuarios_ativo ON usuarios(ativo);
+
 -- Tabela de Clusters
 CREATE TABLE IF NOT EXISTS clusters (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -104,3 +120,22 @@ CREATE INDEX IF NOT EXISTS idx_status_data ON status_tecnico(data);
 CREATE INDEX IF NOT EXISTS idx_status_cluster ON status_tecnico(cluster_id);
 CREATE INDEX IF NOT EXISTS idx_status_usina ON status_tecnico(usina_id);
 CREATE INDEX IF NOT EXISTS idx_status_tecnico ON status_tecnico(tecnico_id);
+
+-- Tabela de Auditoria
+CREATE TABLE IF NOT EXISTS auditoria (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    usuario_id INTEGER NOT NULL,
+    acao VARCHAR(50) NOT NULL,
+    tabela VARCHAR(100) NOT NULL,
+    registro_id INTEGER,
+    dados_antes TEXT,
+    dados_depois TEXT NOT NULL,
+    ip_address VARCHAR(100),
+    user_agent TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_auditoria_usuario ON auditoria(usuario_id);
+CREATE INDEX IF NOT EXISTS idx_auditoria_tabela ON auditoria(tabela);
+CREATE INDEX IF NOT EXISTS idx_auditoria_created_at ON auditoria(created_at);

--- a/backend/database/seedData.sql
+++ b/backend/database/seedData.sql
@@ -62,8 +62,12 @@ INSERT OR IGNORE INTO tecnicos (nome, funcao, cluster_id, ativo) VALUES
 ('Igor Souza', 'Mantenedor', 5, 1);
 
 -- Inserir Funções
-INSERT OR IGNORE INTO funcoes (nome, descricao) VALUES 
+INSERT OR IGNORE INTO funcoes (nome, descricao) VALUES
 ('Eletricista', 'Responsável por atividades elétricas'),
 ('Técnico de Campo', 'Atividades gerais de campo'),
 ('Supervisor', 'Supervisão de equipes'),
 ('Operador', 'Operação de equipamentos');
+
+-- Inserir usuário administrador padrão
+INSERT OR IGNORE INTO usuarios (nome, email, senha, role, clusters_permitidos, ativo) VALUES
+('Administrador', 'admin@empresa.com', '$2b$10$E0dR.WF0qsUIwdgHljWFzOc7lMmvTE4nveQ5oyN9hamSWkQmdqucO', 'admin', '[1,2,3,4,5]', 1);


### PR DESCRIPTION
## Summary
- add the usuarios table with indexes so authentication queries run without hitting missing-table errors
- seed a default administrator user for new databases
- create the auditoria table and indexes referenced by the audit middleware

## Testing
- node backend/server.js

------
https://chatgpt.com/codex/tasks/task_e_68cdeae4e140832e9a4b209dd510ec51