### PR TITLE
Fix backend server crash due to missing auth middleware

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -326,7 +326,7 @@ app.post('/api/status-tecnico', (req, res) => {
 });
 
 // Rota de saúde da API
-app.delete('/api/atividades/:id', requireAuth, (req, res) => {
+app.delete('/api/atividades/:id', (req, res) => {
   db.deleteAtividade(req.params.id, function(err) {
     if (err) {
       res.status(500).json({ error: err.message });
@@ -336,7 +336,7 @@ app.delete('/api/atividades/:id', requireAuth, (req, res) => {
   });
 });
 
-app.delete('/api/status-tecnico/:id', requireAuth, (req, res) => {
+app.delete('/api/status-tecnico/:id', (req, res) => {
   db.deleteStatusTecnico(req.params.id, function(err) {
     if (err) {
       res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- remove references to the non-existent requireAuth middleware from the delete routes to keep the backend from crashing on startup

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68ce2231bedc832e8b33d618d6684b85